### PR TITLE
Nystrom approximate inference for sparse GPs

### DIFF
--- a/demos/sparse.py
+++ b/demos/sparse.py
@@ -26,15 +26,20 @@ if __name__ == '__main__':
     # create a sparse GP.
     U = np.linspace(-1.3, 2, 10)[:, None]
     gp2 = pygp.inference.FITC.from_gp(gp1, U)
-    gp2.add_data(X, y)
 
     # find the ML parameters for both
     pygp.optimize(gp1)
     pygp.optimize(gp2)
 
+    # create a Nystrom GP
+    gp3 = pygp.inference.NystromGP.from_gp(gp1, U)
+
     # plot them.
-    pygp.plotting.plot(gp1, figure=1, subplot=121, ymin=-2.5, ymax=3,
+    pygp.plotting.plot(gp1, figure=1, subplot=131, ymin=-2.5, ymax=3,
                        title='Full GP')
 
-    pygp.plotting.plot(gp2, figure=1, subplot=122, ymin=-2.5, ymax=3,
-                       title='Sparse GP', pseudoinputs=True, legend=True)
+    pygp.plotting.plot(gp2, figure=1, subplot=132, ymin=-2.5, ymax=3,
+                       title='SGP (FITC)', pseudoinputs=True, legend=True)
+
+    pygp.plotting.plot(gp3, figure=1, subplot=133, ymin=-2.5, ymax=3,
+                       title='SGP (Nystrom)', pseudoinputs=True)

--- a/pygp/inference/__init__.py
+++ b/pygp/inference/__init__.py
@@ -6,12 +6,15 @@ Objects which implement GP inference.
 from .exact import *
 from .fitc import *
 from .basic import *
+from .nystrom import *
 
 from . import exact
 from . import fitc
 from . import basic
+from . import nystrom
 
 __all__ = []
 __all__ += exact.__all__
 __all__ += fitc.__all__
 __all__ += basic.__all__
+__all__ += nystrom.__all__

--- a/pygp/inference/nystrom.py
+++ b/pygp/inference/nystrom.py
@@ -1,0 +1,146 @@
+"""
+Nystrom approximate inference in a Gaussian process model
+for regression.
+"""
+
+# future imports
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
+# global imports
+import numpy as np
+import scipy.linalg as sla
+
+# local imports
+from ..utils.exceptions import ModelError
+from ..likelihoods import Gaussian
+from ._base import GP
+
+# exported symbols
+__all__ = ['NystromGP']
+
+
+class NystromGP(GP):
+    """Nystrom approximation to GP inference."""
+
+    def __init__(self, likelihood, kernel, U):
+        # NOTE: exact inference will only work with Gaussian likelihoods.
+        if not isinstance(likelihood, Gaussian):
+            raise ModelError('exact inference requires a Gaussian likelihood')
+
+        super(NystromGP, self).__init__(likelihood, kernel)
+        # save the pseudo-input locations.
+        self._U = np.array(U, ndmin=2, dtype=float, copy=True)
+
+        self._Kinv = None
+        # approximate eigenvalues and eigenvectors
+        self._w = None
+        self._V = None
+
+    @property
+    def pseudoinputs(self):
+        """The pseudo-input points."""
+        return self._U
+
+    def _update(self):
+        sn2 = self._likelihood.s2
+        m = self._U.shape[0]
+        eye = np.eye(m)
+
+        Kuu = self._kernel.get(self._U)
+
+        # compute eigenvalues and eigenvectors of smaller problem
+        w, V = sla.eigh(Kuu)
+
+        # approximate eigenvalues and eigenvectors of larger problem
+        Knm = self._kernel.get(self._X, self._U)
+        scalar = self.ndata / m
+        self._V = np.dot(Knm, V / w) / np.sqrt(scalar)
+        self._w = w * scalar
+
+        # compute the inverse efficiently using Eq. 11 from
+        # (Williams and Seeger, 2001)
+        b = self._w * self._V
+        A = np.dot(b.T, self._V) + sn2 * eye
+        self._Kinv = sla.solve(A, b.T)
+        self._Kinv = np.eye(self.ndata) - np.dot(self._V, self._Kinv)
+        self._Kinv /= sn2
+
+    def _posterior(self, X):
+        # grab the prior mean and covariance.
+        mu = np.zeros(X.shape[0])
+        Sigma = self._kernel.get(X)
+
+        if self._X is not None:
+            K = self._kernel.get(self._X, X)
+            KinvK = np.dot(self._Kinv, K)
+
+            # add the contribution to the mean coming from the posterior and
+            # subtract off the information gained in the posterior from the
+            # prior variance.
+            mu += np.dot(KinvK.T, self._y)
+            Sigma -= np.dot(K.T, KinvK)
+
+        return mu, Sigma
+
+    def posterior(self, X, grad=False):
+        # grab the prior mean and variance.
+        mu = np.zeros(X.shape[0])
+        s2 = self._kernel.dget(X)
+
+        if self._X is not None:
+            K = self._kernel.get(self._X, X)
+            KinvK = np.dot(self._Kinv, K)
+
+            # add the contribution to the mean coming from the posterior and
+            # subtract off the information gained in the posterior from the
+            # prior variance.
+            mu += np.dot(KinvK.T, self._y)
+            s2 -= np.sum(K * KinvK, axis=0)
+
+        if not grad:
+            return (mu, s2)
+
+        # Get the prior gradients. Note that this assumes a constant mean and
+        # stationary kernel.
+        dmu = np.zeros_like(X)
+        ds2 = np.zeros_like(X)
+
+        if self._X is not None:
+            dK = self._kernel.grady(self._X, X)
+            dK = dK.reshape(self.ndata, -1)
+
+            KinvdK = np.dot(self._Kinv.T, dK)
+            dmu += np.dot(KinvdK.T, self._y).reshape(X.shape)
+
+            dK = np.rollaxis(np.reshape(dK, (-1,) + X.shape), 2)
+            ds2 -= 2 * np.sum(dK * KinvK, axis=1).T
+
+        return (mu, s2, dmu, ds2)
+
+    def loglikelihood(self, grad=False):
+        sn2 = self._likelihood.s2
+
+        lZ = -0.5 * np.dot(self._y.T, self._Kinv.dot(self._y))
+        lZ -= 0.5 * np.log(2*np.pi) * self.ndata
+        lZ -= np.sum(np.log(self._w + sn2))
+
+        # bail early if we don't need the gradient.
+        if not grad:
+            return lZ
+
+        # # intermediate terms.
+        # alpha = sla.solve_triangular(self._R, self._a, trans=False)
+        # Q = sla.cho_solve((self._R, False), np.eye(self.ndata))
+        # Q -= np.outer(alpha, alpha)
+        #
+        # dlZ = np.r_[
+        #     # derivative wrt the likelihood's noise term.
+        #     -self._likelihood.s2 * np.trace(Q),
+        #
+        #     # derivative wrt each kernel hyperparameter.
+        #     [-0.5*np.sum(Q*dK)
+        #      for dK in self._kernel.grad(self._X)]]
+        #
+        # return lZ, dlZ


### PR DESCRIPTION
This branch adds the Nystrom approximate inference method. A few notes:
1. I'm unsure about the current `loglikelihood()` method and it certainly does not have a gradient computation implemented though I don't think this will necessarily be difficult to code up.
2. I had the original implementation (Williams and Seeger, 2001) coded up but it was extremely unstable, I believe, due to the random subset of data points acting as inducing points. Granted, the limited synthetic datasets I looked at had relatively few data points (<1000 in 1D); we should consider random subsampling of the data at a later date. For now I'm just passing the inducing points at initialization (as is done in the `FITC` class).
3. The `sparse.py` demo in this branch includes `NystromGP` to compare against `FITC` and the full `ExactGP`. With the same inducing points, `NystromGP` performs worse than `FITC` as it is. It begins to predict (GP mean) better as we consider 12 inducing points (60%; the full GP has 20) but with nonsensical uncertainty bands. This is a known issue with the Nystrom method as proposed by (Williams and Seeger, 2001); as is discussed in Section 10 of (Quiñonero-Candela and Rasmussen, 2005), the Nystrom approximation is no longer a valid probabilistic model and the predictive covariance is not positive definite, hence the inexistent uncertainty bands in certain regions.
4. This issue is supposedly fixed by the deterministic training conditional (DTC) method. I'm looking into this next.
